### PR TITLE
Simplify settings path lookup

### DIFF
--- a/PerformanceImprovements/Graphics/GraphicSettingsManager.cs
+++ b/PerformanceImprovements/Graphics/GraphicSettingsManager.cs
@@ -13,10 +13,7 @@ public static class GraphicSettingsManager
     
     static GraphicSettingsManager()
     {
-        var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-        var dir = Directory.GetParent(path).FullName;
-        
-        _settingsPath = Path.Combine(dir, "config", "com.dirtbikercj.performanceimprovements.graphicsettings.json");
+        _settingsPath = Path.Combine(BepInEx.Paths.ConfigPath, "com.dirtbikercj.performanceimprovements.graphicsettings.json");
     }
     
     public static SettingsModel SettingsModel { get; private set; }


### PR DESCRIPTION
Since the code are basically just doing "../config/com.dirtbikercj.performanceimprovements.graphicsettings.json", I made it to use built-in BepInEx variable.
Fixes if user have another folder in "plugins" causing exception because "BepInEx/plugins/config" folder does not exist. (for example "_BepInEx/plugins/Performance Improvements/PerformanceImprovements.dll_")
Cause no harm if user are installing it by the normal way.